### PR TITLE
refactor: separate generation and logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,13 @@ RUN python3 -m pip install --upgrade pip
 
 # Install any python packages you need
 COPY ./requirements.txt requirements.txt
-
 RUN python3 -m pip install -r requirements.txt
 
 # Install PyTorch and torchvision
-RUN pip3 install torch torchvision torchaudio -f https://download.pytorch.org/whl/cu118
+RUN python3 -m pip install torch torchvision torchaudio -f https://download.pytorch.org/whl/cu118
+
+# Add the shell script to pull models and benchmark the HF hub
+COPY ./scripts/fetch_and_benchmark.sh fetch_and_benchmark.sh
 
 # Set the working directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,19 @@ services:
       context: .
       dockerfile: Dockerfile
     image: llm_bench
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
     volumes:
       - ./llm_benchmarks:/app/llm_benchmarks
+      - ./logs/:/var/log
+    network_mode: host
     ports:
       - "5000:5000" # for flask
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - ./llm_benchmarks:/app/llm_benchmarks
       - ./logs/:/var/log
+      - /data/hf:/data/hf
     network_mode: host
     ports:
       - "5000:5000" # for flask

--- a/llm_benchmarks/api.py
+++ b/llm_benchmarks/api.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 from flask import Flask
@@ -7,12 +8,18 @@ from flask.wrappers import Response
 from llm_benchmarks.config import ModelConfig
 from llm_benchmarks.generation import generate_and_log
 
+
+logging.basicConfig(filename="/var/log/llm_benchmarks.log", level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
 app = Flask(__name__)
 
 
 @app.route("/benchmark/<model_name>", methods=["POST"])
 def call_benchmark(model_name: str) -> Response:
     """Enables the use a POST request to call the benchmarking function."""
+
+    logger.info(f"Received request for model {model_name}")
 
     # Declare config defaults
     config = ModelConfig(

--- a/llm_benchmarks/api.py
+++ b/llm_benchmarks/api.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from urllib.parse import unquote
 
 from flask import Flask
 from flask import jsonify
@@ -15,9 +16,10 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 
 
-@app.route("/benchmark/<model_name>", methods=["POST"])
+@app.route("/benchmark/<path:model_name>", methods=["POST"])
 def call_benchmark(model_name: str) -> Response:
     """Enables the use a POST request to call the benchmarking function."""
+    model_name = unquote(model_name)
 
     logger.info(f"Received request for model {model_name}")
 

--- a/llm_benchmarks/api.py
+++ b/llm_benchmarks/api.py
@@ -9,7 +9,7 @@ from llm_benchmarks.config import ModelConfig
 from llm_benchmarks.generation import generate_and_log
 
 
-logging.basicConfig(filename="/var/log/llm_benchmarks.log", level=logging.DEBUG)
+logging.basicConfig(filename="/var/log/llm_benchmarks.log", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)

--- a/llm_benchmarks/api.py
+++ b/llm_benchmarks/api.py
@@ -5,7 +5,7 @@ from flask import jsonify
 from flask.wrappers import Response
 
 from llm_benchmarks.config import ModelConfig
-from llm_benchmarks.generation import generate
+from llm_benchmarks.generation import generate_and_log
 
 app = Flask(__name__)
 
@@ -16,6 +16,7 @@ def call_benchmark(model_name: str) -> Response:
 
     # Declare config defaults
     config = ModelConfig(
+        model_name=model_name,
         # quantization_bits="8bit",
         quantization_bits=None,
         # torch_dtype="float16",
@@ -25,7 +26,7 @@ def call_benchmark(model_name: str) -> Response:
     )
 
     # Your benchmarking logic here
-    result = generate(model_name, config)
+    result = generate_and_log(config)
     return jsonify(result)
 
 

--- a/llm_benchmarks/config.py
+++ b/llm_benchmarks/config.py
@@ -1,4 +1,8 @@
+import logging
 from typing import Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 class ModelConfig:

--- a/llm_benchmarks/config.py
+++ b/llm_benchmarks/config.py
@@ -2,7 +2,15 @@ from typing import Optional
 
 
 class ModelConfig:
-    def __init__(self, run_ts: str, torch_dtype: str, temperature: float, quantization_bits: Optional[str] = None):
+    def __init__(
+        self,
+        model_name: str,
+        run_ts: str,
+        torch_dtype: str,
+        temperature: float,
+        quantization_bits: Optional[str] = None,
+    ):
+        self.model_name = model_name
         self.run_ts = run_ts
         self.torch_dtype = torch_dtype
         self.temperature = temperature

--- a/llm_benchmarks/generation.py
+++ b/llm_benchmarks/generation.py
@@ -106,7 +106,7 @@ def generate(
         time1 = time()
 
         # Collect metrics
-        output_tokens = len(output.cpu().numpy().tolist()[0]) if output else 0
+        output_tokens = len(output.cpu().numpy().tolist()[0]) if output is not None and output.numel() > 0 else 0
         gpu_mem_usage = torch.cuda.memory_allocated()
         generate_time = time1 - time0
         tokens_per_second = output_tokens / generate_time

--- a/llm_benchmarks/generation.py
+++ b/llm_benchmarks/generation.py
@@ -16,7 +16,6 @@ from llm_benchmarks.config import ModelConfig
 
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
-os.environ["CUDA_VISIBLE_DEVICES"] = "1"
 os.environ["HUGGINGFACE_HUB_CACHE"] = "/data/hf/"
 
 logger = logging.getLogger(__name__)
@@ -90,6 +89,7 @@ def generate(
     for ix, token_count in enumerate(requested_tokens):
         logger.info(f"Generating sample for token count {token_count}")
         time0 = time()
+        output = None
         try:
             output = model.generate(
                 input_tokens,
@@ -106,7 +106,7 @@ def generate(
         time1 = time()
 
         # Collect metrics
-        output_tokens = len(output.cpu().numpy().tolist()[0])
+        output_tokens = len(output.cpu().numpy().tolist()[0]) if output else 0
         gpu_mem_usage = torch.cuda.memory_allocated()
         generate_time = time1 - time0
         tokens_per_second = output_tokens / generate_time

--- a/llm_benchmarks/generation.py
+++ b/llm_benchmarks/generation.py
@@ -1,3 +1,4 @@
+"""Module for benchmarking llm infernce speeds and external logging."""
 import gc
 import logging
 import os
@@ -20,30 +21,20 @@ logger = logging.getLogger(__name__)
 MONGODB_URI = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
 
 
-def setup_database(db_name: str) -> Collection:
-    client = pymongo.MongoClient(MONGODB_URI)
-    db = client[db_name]
-    collection = db["benchmark_metrics"]
-    return collection
-
-
-def insert_into_benchmark_metrics(data: dict, collection: Collection) -> None:
-    collection.insert_one(data)
-
-
-# Functionality deprecated by pip
-def get_installed_packages() -> str:
-    # packages = {package.project_name: package.version for package in pip.get_installed_distributions()}
-    # return json.dumps(packages)
-    return ""
+def generate_and_log(
+    config,
+    custom_token_counts: list = [],
+    llama: bool = False,
+    db_name: str = "llm_benchmarks",
+) -> None:
+    metrics = generate(config, custom_token_counts, llama)
+    log_to_mongo(config, metrics, db_name)
 
 
 def generate(
-    model_name: str,
     config: ModelConfig,
     custom_token_counts: list = [],
     llama: bool = False,
-    db_name: str = "benchmark_metrics",
 ) -> dict:
     if llama:
         from transformers import LlamaForCausalLM as Model  # type: ignore
@@ -54,22 +45,22 @@ def generate(
 
     # Load Model
     model = Model.from_pretrained(
-        model_name,
+        config.model_name,
         load_in_4bit=config.load_in_4bit,
         load_in_8bit=config.load_in_8bit,
         torch_dtype=config.torch_dtype,
         device_map="auto",
         trust_remote_code=True,
     )
-    # model.eval()  # type: ignore
-    # model = torch.compile(model)  # type: ignore
 
     # Tokenize inputs
-    tokenizer = Tokenizer.from_pretrained(model_name)
+    tokenizer = Tokenizer.from_pretrained(config.model_name)
     text = "Hi: "
     input_tokens = tokenizer(text, return_tensors="pt").input_ids.to("cuda")
 
     metrics = {
+        "gen_ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "requested_tokens": [],
         "output_tokens": [],
         "gpu_mem_usage": [],
         "generate_time": [],
@@ -77,20 +68,13 @@ def generate(
     }
 
     if custom_token_counts:
-        token_counts = custom_token_counts
+        requested_tokens = custom_token_counts
     else:
-        token_counts = [32, 64, 128, 256, 512, 1024]
-
-    # MongoDB
-    collection = setup_database(db_name)
-
-    # Get installed packages as JSON string
-    lib_versions = get_installed_packages()
+        requested_tokens = [64, 128, 256, 512, 1024]
 
     # Generate samples
-    for i, token_count in enumerate(token_counts):
+    for ix, token_count in enumerate(requested_tokens):
         time0 = time()
-        # with torch.no_grad():
         output = model.generate(
             input_tokens,
             do_sample=True,
@@ -104,38 +88,22 @@ def generate(
 
         # Collect metrics
         output_tokens = len(output.cpu().numpy().tolist()[0])
-        gpu_mem_usage = torch.cuda.memory_allocated() / 1024**3
+        gpu_mem_usage = torch.cuda.memory_allocated()
         generate_time = time1 - time0
         tokens_per_second = output_tokens / generate_time
 
-        # MongoDB metrics
-        data = {
-            "run_ts": config.run_ts,
-            "model_name": model_name,
-            "quantization_bits": config.quantization_bits,
-            "torch_dtype": config.torch_dtype,
-            "temperature": config.temperature,
-            "gen_ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "model_name": model_name,
-            "lib_versions": lib_versions,
-            "token_count": token_count,
-            "output_tokens": output_tokens,
-            "gpu_mem_usage": gpu_mem_usage,
-            "generate_time": generate_time,
-            "tokens_per_second": tokens_per_second,
-        }
-        insert_into_benchmark_metrics(data, collection)
-
         # Append metrics to the metrics dict
+        metrics["requested_tokens"].append(token_count)
         metrics["output_tokens"].append(output_tokens)
         metrics["gpu_mem_usage"].append(gpu_mem_usage)
         metrics["generate_time"].append(generate_time)
         metrics["tokens_per_second"].append(tokens_per_second)
 
         # logger.info metrics
-        logger.info(f"===== Model: {model_name} Run: {i+1}/{len(token_counts)} =====")
+        logger.info(f"===== Model: {config.model_name} Run: {ix+1}/{len(requested_tokens)} =====")
+        logger.info(f"Requested tokens: {token_count}")
         logger.info(f"Output tokens: {output_tokens}")
-        logger.info(f"GPU mem usage: {gpu_mem_usage:.2f} GB")
+        logger.info(f"GPU mem usage: {(gpu_mem_usage / 1024**3) :.2f}GB")
         logger.info(f"Generate time: {generate_time:.2f} s")
         logger.info(f"Tokens per second: {tokens_per_second:.2f}")
 
@@ -144,3 +112,33 @@ def generate(
     torch.cuda.empty_cache()
 
     return metrics
+
+
+def log_to_mongo(config: ModelConfig, metrics: dict, db_name: str) -> None:
+    collection = setup_database(db_name)
+
+    data = {
+        "run_ts": config.run_ts,
+        "model_name": config.model_name,
+        "quantization_bits": config.quantization_bits,
+        "torch_dtype": config.torch_dtype,
+        "temperature": config.temperature,
+        "gen_ts": metrics["gen_ts"],
+        "requested_tokens": metrics["requested_tokens"],
+        "output_tokens": metrics["output_tokens"],
+        "gpu_mem_usage": metrics["gpu_mem_usage"],
+        "generate_time": metrics["generate_time"],
+        "tokens_per_second": metrics["tokens_per_second"],
+    }
+    insert_into_benchmark_metrics(data, collection)
+
+
+def setup_database(db_name: str) -> Collection:
+    client = pymongo.MongoClient(MONGODB_URI)
+    db = client[db_name]
+    collection = db["benchmark_metrics"]
+    return collection
+
+
+def insert_into_benchmark_metrics(data: dict, collection: Collection) -> None:
+    collection.insert_one(data)

--- a/llm_benchmarks/generation.py
+++ b/llm_benchmarks/generation.py
@@ -158,6 +158,7 @@ def log_to_mongo(
             "tokens_per_second": metrics["tokens_per_second"],
         }
         insert_into_benchmark_metrics(data, collection)
+        logger.info(f"Successfully logged metrics to MongoDB for model {config.model_name}")
     except Exception as e:
         logger.exception(f"Error in log_to_mongo: {e}")
 

--- a/scripts/fetch_and_benchmark.sh
+++ b/scripts/fetch_and_benchmark.sh
@@ -1,28 +1,26 @@
 #!/bin/bash
 
-# Array to store the response codes for each model
 declare -A modelStatus
 
-# Get top 10 trending models
 models=$(curl -s -G "https://huggingface.co/api/models" \
     --data-urlencode "sort=downloads" \
     --data-urlencode "direction=-1" \
     --data-urlencode "limit=10" \
     --data-urlencode "filter=text-generation" | jq -r '.[].id')
 
-# Run benchmarks on each model
 for model in $models; do
-    echo "Running benchmark for model: $model"
-    responseCode=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:5000/benchmark/$model")
-    echo "Finished benchmark for model: $model with HTTP Response Code: $responseCode"
+    # Encode the forward slashes in the model name
+    encodedModel=$(echo "$model" | sed 's/\//%2F/g')
 
-    # Store the response code in the array
+    echo "Running benchmark: $model"
+    responseCode=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:5000/benchmark/$encodedModel")
+    echo "Finished benchmark: $model with Status Code: $responseCode"
+
     modelStatus["$model"]=$responseCode
 done
 
 echo "All benchmark runs are finished."
 
-# Print out the models and their respective response codes
 echo "Summary of benchmark runs:"
 for model in "${!modelStatus[@]}"; do
   echo "Model: $model, HTTP Response Code: ${modelStatus[$model]}"


### PR DESCRIPTION
This MR moves the mongo logging outside of the generation function. This will enable cleaner code moving forward as well as better error handling in case the generation task fails, so that we can still log failed runs.